### PR TITLE
Minor POM updates for a priming build.

### DIFF
--- a/blojsom-core/pom.xml
+++ b/blojsom-core/pom.xml
@@ -34,6 +34,10 @@
                     <groupId>ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.transaction</groupId>
+                    <artifactId>jta</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -44,7 +48,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring</artifactId>
-            <version>2.0-m4</version>
+            <version>${spring.version}</version>
         </dependency>
     </dependencies>
     <parent>

--- a/blojsom-metrics/pom.xml
+++ b/blojsom-metrics/pom.xml
@@ -2,9 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- The Basics -->
-    <groupId>${parent.groupId}</groupId>
     <artifactId>blojsom-metrics</artifactId>
-    <version>${parent.version}</version>
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-maven</artifactId>

--- a/quickrstart/pom.xml
+++ b/quickrstart/pom.xml
@@ -2,9 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- The Basics -->
-    <groupId>${parent.groupId}</groupId>
     <artifactId>blojsom-quickrstart</artifactId>
-    <version>${parent.version}</version>
     <packaging>war</packaging>
     <dependencies>
         <dependency>


### PR DESCRIPTION
JTA 1.0.1B excluded from the hibernate dependency (build picks up current
1.1 automatically). 

Removed build warning on sub-projects where `groupId` and `version` should be 
inherited as a constants.