### PR TITLE
Updated Hibernate to v3.2.7.ga that included patch for HHH-3401 that

### DIFF
--- a/blojsom-library/pom.xml
+++ b/blojsom-library/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <groovy.version>1.0</groovy.version>
         <commons-logging.version>1.0.4</commons-logging.version>
-        <org.hibernate.version>3.1.3</org.hibernate.version>
+        <org.hibernate.version>3.2.7.ga</org.hibernate.version>
         <org.slf4j.version>1.3.0</org.slf4j.version>
         <velocity.version>1.6.2</velocity.version>
         <servlet-api.version>2.5</servlet-api.version>

--- a/quickrstart/pom.xml
+++ b/quickrstart/pom.xml
@@ -6,9 +6,9 @@
     <packaging>war</packaging>
     <dependencies>
         <dependency>
-            <groupId>hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
-            <version>1.8.0.10</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.192</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/quickrstart/src/main/resources/blojsom-helper-beans-include.xml
+++ b/quickrstart/src/main/resources/blojsom-helper-beans-include.xml
@@ -11,8 +11,8 @@
     </bean>
 
     <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
-        <property name="driverClassName" value="org.hsqldb.jdbcDriver"/>
-        <property name="url" value="jdbc:hsqldb:mem:blojsom"/>
+        <property name="driverClassName" value="org.h2.Driver"/>
+        <property name="url" value="jdbc:h2:mem:blojsom"/>
         <property name="username" value="sa"/>
         <property name="password" value=""/>
     </bean>
@@ -36,7 +36,6 @@
                 <prop key="c3p0.max_size">50</prop>
                 <prop key="c3p0.timeout">1800</prop>
                 <prop key="c3p0.max_statements">100</prop>
-                <prop key="show_sql">false</prop>
                 <prop key="show_sql">true</prop>
                 <prop key="hbm2ddl.auto">create-drop</prop>
                 <prop key="hibernate.dialect">org.hibernate.dialect.HSQLDialect</prop>

--- a/quickrstart/src/main/resources/blojsom.xml
+++ b/quickrstart/src/main/resources/blojsom.xml
@@ -52,13 +52,13 @@
         <property name="sessionFactory">
             <ref bean="hibernateSessionFactory"/>
         </property>
-        <property name="dbScript" value="/WEB-INF/classes/blojsom-full-initial-data-hsqldb.sql"/>
+        <property name="dbScript" value="/WEB-INF/classes/blojsom-full-initial-data-h2.sql"/>
         <property name="upgrading" value="false"/>
         <property name="servletConfig">
             <ref bean="servletConfigFactoryBean"/>
         </property>
         <property name="detectBlojsomSQL">
-            <value>select table_name from information_schema.system_tables where table_name = 'BLOG';</value>
+            <value>select table_name from information_schema.TABLES where table_name = 'BLOG';</value>
         </property>
 
     </bean>
@@ -73,7 +73,7 @@
         </property>
     </bean>
 
-    <bean id="eventBroadcaster" class="org.blojsom.event.SimpleEventBroadcaster">
+    <bean id="eventBroadcaster" class="org.blojsom.event.pojo.BasicEventBroadcaster">
     </bean>
 
     <!-- Fetcher (for database interaction) -->


### PR DESCRIPTION
improved the H2Dialect support.

H2 in-memory update including information.schema selection on TABLES.

POJO BasicEventBroadcaster update.