### PR TITLE
Address CVE-2019-17571 by upgrading log4j

### DIFF
--- a/blojsom-plugins/pom.xml
+++ b/blojsom-plugins/pom.xml
@@ -114,10 +114,15 @@
             <version>1.1</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.8</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.13.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.13.0</version>
+        </dependency> 
         <dependency>
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache</artifactId>
@@ -206,10 +211,10 @@
             <version>2.0.1</version>
         </dependency>
         <dependency>
-           <groupId>org.twitter4j</groupId>
-           <artifactId>twitter4j-core</artifactId>
-           <version>[2.2,]</version>
-       </dependency>
+            <groupId>org.twitter4j</groupId>
+            <artifactId>twitter4j-core</artifactId>
+            <version>[2.2,]</version>
+        </dependency>
     </dependencies>
     <parent>
         <groupId>org.blojsom</groupId>

--- a/blojsom-plugins/src/main/java/org/blojsom/plugin/notification/AbstractVelocityEmailNotification.java
+++ b/blojsom-plugins/src/main/java/org/blojsom/plugin/notification/AbstractVelocityEmailNotification.java
@@ -31,7 +31,8 @@
 package org.blojsom.plugin.notification;
 
 import org.apache.commons.mail.Email;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.springframework.web.context.ServletContextAware;
@@ -54,7 +55,7 @@ public abstract class AbstractVelocityEmailNotification extends AbstractNotifica
 
     private String velocityPropsPath;
 
-    private static final Logger logger = Logger.getLogger(AbstractVelocityEmailNotification.class);
+    private static final Logger logger = LogManager.getLogger(AbstractVelocityEmailNotification.class);
 
     /**
      * Construct a new abstract velocity e-mail notification


### PR DESCRIPTION
log4j 1.x was retired in 2015. A single plugin used the log4j library.
The class was upgraded to log4j 2.x, however, the opportunity to
leverage ACL is open as the project relies heavily on ACL.