### PR TITLE
Update log4j config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-3.5.2-SNAPSHOT [![CircleCI](https://circleci.com/gh/timothystone/blojsom/tree/master.svg?style=shield)](https://circleci.com/gh/timothystone/blojsom/tree/master)
+3.5.4-SNAPSHOT [![CircleCI](https://circleci.com/gh/timothystone/blojsom/tree/master.svg?style=shield)](https://circleci.com/gh/timothystone/blojsom/tree/master)
 
 blojsom is ...
 ==============

--- a/blojsom-api/pom.xml
+++ b/blojsom-api/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-library</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
         <relativePath>../blojsom-library/pom.xml</relativePath>
     </parent>
     <properties>

--- a/blojsom-core/pom.xml
+++ b/blojsom-core/pom.xml
@@ -54,7 +54,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-library</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
         <relativePath>../blojsom-library/pom.xml</relativePath>
     </parent>
     <properties>

--- a/blojsom-extensions/pom.xml
+++ b/blojsom-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-library</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
         <relativePath>../blojsom-library/pom.xml</relativePath>
     </parent>
     <properties>

--- a/blojsom-library/pom.xml
+++ b/blojsom-library/pom.xml
@@ -4,7 +4,7 @@
     <!-- The Basics -->
     <groupId>org.blojsom</groupId>
     <artifactId>blojsom-library</artifactId>
-    <version>3.5.3-SNAPSHOT</version>
+    <version>3.5.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>../blojsom-api</module>
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-maven</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
     </parent>
     <dependencyManagement>
         <dependencies>

--- a/blojsom-metrics/pom.xml
+++ b/blojsom-metrics/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-maven</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
     </parent>
     <!-- More Project Information -->
     <name>blojsom Metrics Configuration</name>

--- a/blojsom-plugins-templates/pom.xml
+++ b/blojsom-plugins-templates/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-maven</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
     </parent>
     <properties>
         <metrics.exclude>false</metrics.exclude>

--- a/blojsom-plugins/pom.xml
+++ b/blojsom-plugins/pom.xml
@@ -124,6 +124,16 @@
             <version>[2.17.0,)</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jcl</artifactId>
+            <version>[2.17.0,)</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-web</artifactId>
+            <version>[2.17.0,)</version>
+        </dependency>
+        <dependency>
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache</artifactId>
             <version>1.2.3</version>
@@ -219,7 +229,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-library</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
         <relativePath>../blojsom-library/pom.xml</relativePath>
     </parent>
     <properties>

--- a/blojsom-pojos/pom.xml
+++ b/blojsom-pojos/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-library</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
         <relativePath>../blojsom-library/pom.xml</relativePath>
     </parent>
     <properties>

--- a/blojsom-resources/pom.xml
+++ b/blojsom-resources/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-maven</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
     </parent>
     <properties>
         <metrics.exclude>false</metrics.exclude>

--- a/blojsom/pom.xml
+++ b/blojsom/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-maven</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
     </parent>
     <properties>
         <ide.server>Tomcat</ide.server>

--- a/blojsom/src/main/resources/log4j2.xml
+++ b/blojsom/src/main/resources/log4j2.xml
@@ -2,16 +2,17 @@
 <Configuration>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5p [%t] %c{1.}:%L - %m%n"/>
+      <PatternLayout pattern="%d{yyyy-MM-dd'T'HH:mm:ss.SSSZZZZ} %-5p [%t] %c{1.}:%L - %m%n" />
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="net.sf.ehcache" level="error"/>
-    <Logger name="org.hibernate" level="error"/>
-    <Logger name="org.springframework" level="error"/>
-    <Logger name="org.apache.commons.digester.Digester" level="INFO"/>
+    <Logger name="net.sf.ehcache" level="error" />
+    <Logger name="org.hibernate" level="error" />
+    <Logger name="org.springframework" level="error" />
+    <Logger name="org.apache.commons.digester.Digester" level="info" />
+    <Logger name="org.blojsom" level="debug" />
     <Root level="debug">
-      <AppenderRef ref="STDOUT"/>
+      <AppenderRef ref="STDOUT" />
     </Root>
   </Loggers>
 </Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <!-- The Basics -->
     <groupId>org.blojsom</groupId>
     <artifactId>blojsom-maven</artifactId>
-    <version>3.5.3-SNAPSHOT</version>
+    <version>3.5.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>blojsom-metrics</module>

--- a/quickrstart/pom.xml
+++ b/quickrstart/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.blojsom</groupId>
         <artifactId>blojsom-maven</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
     </parent>
     <properties />
     <!-- More Project Information -->

--- a/quickrstart/src/main/resources/blojsom-helper-beans-include.xml
+++ b/quickrstart/src/main/resources/blojsom-helper-beans-include.xml
@@ -12,7 +12,7 @@
 
     <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
         <property name="driverClassName" value="org.hsqldb.jdbcDriver"/>
-        <property name="url" value="jdbc:hsqldb:file:/tmp/blojsom"/>
+        <property name="url" value="jdbc:hsqldb:file:/tmp/blojsom;shutdown=true"/>
         <property name="username" value="SA"/>
         <property name="password" value=""/>
     </bean>


### PR DESCRIPTION
Ostensibly this is to address the log pattern for blojsom. The ISO8601
format is better consumed in cloud logging for synchronization.

Added log4j-web to optimize container, see documentation for log4j for
more information.

Added shutdown hook in database connection string to handle Quick Start.