### PR TITLE
Add github templates for Issues and PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
     # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your 
     # project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred 
     # commands if they are not relevant to your project.
-    - run: mvn integration-test
+    # - run: mvn integration-test
     # Teardown
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are 
     # relevant in each

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+**Note: for support questions, please use stackoverflow**. This repository's issues are reserved for feature requests and bug reports.
+
+* **I'm submitting a ...**
+  - [ ] bug report
+  - [ ] feature request
+  - [ ] support request => Please do not submit support request here, see note at the top of this template.
+
+
+* **Do you want to request a *feature* or report a *bug*?**
+
+
+
+* **What is the current behavior?**
+
+
+
+* **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem** via
+https://plnkr.co or similar (you can use this template as a starting point: http://plnkr.co/edit/tpl:AvJOMERrnz94ekVua0u5).
+
+
+
+* **What is the expected behavior?**
+
+
+
+* **What is the motivation / use case for changing the behavior?**
+
+
+
+* **Please tell us about your environment:**
+  
+  - Version: 2.0.0-beta.X
+  - Browser: [all | Chrome XX | Firefox XX | IE XX | Safari XX | Mobile Chrome XX | Android X.X Web Browser | iOS XX Safari | iOS XX UIWebView | iOS XX WKWebView ]
+  - Language: [all | TypeScript X.X | ES6/7 | ES5 | Dart]
+
+
+* **Other information** (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,37 +1,29 @@
-**Note: for support questions, please use stackoverflow**. This repository's issues are reserved for feature requests and bug reports.
+**Note: for support questions, please use IRC. Join `#blojsom` on `freenode.net`**. 
+> &#x26A0; Freenode requires nick registration and TLS; this is for your safety, not as an inconvenience. I use Thunderbird's built-in IRC client, many others are available on all platforms.
 
-* **I'm submitting a ...**
-  - [ ] bug report
-  - [ ] feature request
-  - [ ] support request => Please do not submit support request here, see note at the top of this template.
+This repository's issues are reserved for feature requests and bug reports.
 
+**I'm submitting a ...**
+- [ ] bug report
+- [ ] feature request
+- [ ] support request, n.b., Please do not submit support request here, see note at the **top** of this template.
 
-* **Do you want to request a *feature* or report a *bug*?**
+**What is the current behavior?**
 
+> &#x26A0; If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem.
 
+**What is the expected behavior?**
 
-* **What is the current behavior?**
+**What is the motivation/use case for changing the behavior?**
 
-
-
-* **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem** via
-https://plnkr.co or similar (you can use this template as a starting point: http://plnkr.co/edit/tpl:AvJOMERrnz94ekVua0u5).
-
-
-
-* **What is the expected behavior?**
-
-
-
-* **What is the motivation / use case for changing the behavior?**
-
-
-
-* **Please tell us about your environment:**
+**Please tell us about your environment:**
   
-  - Version: 2.0.0-beta.X
-  - Browser: [all | Chrome XX | Firefox XX | IE XX | Safari XX | Mobile Chrome XX | Android X.X Web Browser | iOS XX Safari | iOS XX UIWebView | iOS XX WKWebView ]
-  - Language: [all | TypeScript X.X | ES6/7 | ES5 | Dart]
+  - **Version:** 3.5.4-SNAPSHOT
+  - **Java:** [1.8 | 11 | 17]
+  - **Container:** [Tomcat | Other...]
+  - **Container Version:** [8 | 9 | 10 | XX ]
+  - **OS:** [Linux | Mac OS | Windows]
+  - **Database:** [Postgres | MySQL | Other...]
+  - **Database Version:** 
 
-
-* **Other information** (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)
+**Other information**, e.g., detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+* **Please check if the PR fulfills these requirements**
+- [ ] The commit message follows our guidelines
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+
+* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+
+
+
+* **What is the current behavior?** (You can also link to an open issue here)
+
+
+
+* **What is the new behavior (if this is a feature change)?**
+
+
+
+* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+
+
+
+* **Other information**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,17 @@
 **Please check that the PR fulfills the following requirements:**
 
-[ ] The commit message follows our guidelines
+- [ ] The commit message follows our guidelines
 
 1. The subject is in an imperative voice, "*This commit will...* <commit subject>," e.g., `Change the default IMAP port number`, or spoken, `[This commit will] change the default IMAP port number`
-Or more explicitly,
-**Right** `Change the default IMAP port number`
-**Wrong** `This commit will change the default IMAP port number`
+  Or more explicitly,
+  **Right** `Change the default IMAP port number`
+  **Wrong** `This commit will change the default IMAP port number`
 1. The subject is 55 characters or less
 1. The body contains context of all changes made. A body is required and PRs without a body are subject to feedback.
 1. If an ISSUE was opened, the body of the PR contains `closes #nnnn` to automatically close the ISSUE.
 
-[ ] Tests for the changes have been added (for bug fixes / features)
-[ ] Docs have been added / updated (for bug fixes / features)
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
 
 **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,9 @@
 
 - [ ] The commit message follows our guidelines
 
-1. The subject is in an imperative voice, "*This commit will...* <commit subject>," e.g., `Change the default IMAP port number`, or spoken, `[This commit will] change the default IMAP port number`
-    Or more explicitly,
-    **Right** `Change the default IMAP port number`
+1. The subject is in an imperative voice, "*This commit will...* <commit subject>," e.g., `Change the default IMAP port number`, or spoken, `[This commit will] change the default IMAP port number`<br>
+    Or more explicitly,<br>
+    **Right** `Change the default IMAP port number`<br>
     **Wrong** `This commit will change the default IMAP port number`
 1. The subject is 55 characters or less
 1. The body contains context of all changes made. A body is required and PRs without a body are subject to feedback.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,10 @@
 
 - [ ] The commit message follows our guidelines
 
-1. The subject is in an imperative voice, "*This commit will...* <commit subject>," e.g., `Change the default IMAP port number`, or spoken, `[This commit will] change the default IMAP port number`<br>
+1. The subject is in an imperative voice, "*This commit will...* <commit subject>," e.g., `Change the default IMAP port number`<br>
     Or more explicitly,<br>
-    **Right** `Change the default IMAP port number`<br>
-    **Wrong** `This commit will change the default IMAP port number`
+    &#x2705; **Right** `Change the default IMAP port number`<br>
+    &#x274C; **Wrong** `This commit will change the default IMAP port number`
 1. The subject is 55 characters or less
 1. The body contains context of all changes made. A body is required and PRs without a body are subject to feedback.
 1. If an ISSUE was opened, the body of the PR contains `closes #nnnn` to automatically close the ISSUE.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,9 @@
 - [ ] The commit message follows our guidelines
 
 1. The subject is in an imperative voice, "*This commit will...* <commit subject>," e.g., `Change the default IMAP port number`, or spoken, `[This commit will] change the default IMAP port number`
-  Or more explicitly,
-  **Right** `Change the default IMAP port number`
-  **Wrong** `This commit will change the default IMAP port number`
+    Or more explicitly,
+    **Right** `Change the default IMAP port number`
+    **Wrong** `This commit will change the default IMAP port number`
 1. The subject is 55 characters or less
 1. The body contains context of all changes made. A body is required and PRs without a body are subject to feedback.
 1. If an ISSUE was opened, the body of the PR contains `closes #nnnn` to automatically close the ISSUE.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,24 @@
-* **Please check if the PR fulfills these requirements**
-- [ ] The commit message follows our guidelines
-- [ ] Tests for the changes have been added (for bug fixes / features)
-- [ ] Docs have been added / updated (for bug fixes / features)
+**Please check that the PR fulfills the following requirements:**
 
+[ ] The commit message follows our guidelines
 
-* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+1. The subject is in an imperative voice, "*This commit will...* <commit subject>," e.g., `Change the default IMAP port number`, or spoken, `[This commit will] change the default IMAP port number`
+Or more explicitly,
+**Right** `Change the default IMAP port number`
+**Wrong** `This commit will change the default IMAP port number`
+1. The subject is 55 characters or less
+1. The body contains context of all changes made. A body is required and PRs without a body are subject to feedback.
+1. If an ISSUE was opened, the body of the PR contains `closes #nnnn` to automatically close the ISSUE.
 
+[ ] Tests for the changes have been added (for bug fixes / features)
+[ ] Docs have been added / updated (for bug fixes / features)
 
+**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 
-* **What is the current behavior?** (You can also link to an open issue here)
+**What is the current behavior?** (You can also link to an open issue here)
 
+**What is the new behavior (if this is a feature change)?**
 
+**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
 
-* **What is the new behavior (if this is a feature change)?**
-
-
-
-* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
-
-
-
-* **Other information**:
+**Other information**:


### PR DESCRIPTION
**Please check that the PR fulfills the following requirements:**

- [x] The commit message follows our guidelines

1. The subject is in an imperative voice, "*This commit will...* <commit subject>," e.g., `Change the default IMAP port number`<br>
    Or more explicitly,<br>
    &#x2705; **Right** `Change the default IMAP port number`<br>
    &#x274C; **Wrong** `This commit will change the default IMAP port number`
1. The subject is 55 characters or less
1. The body contains context of all changes made. A body is required and PRs without a body are subject to feedback.
1. If an ISSUE was opened, the body of the PR contains `closes #nnnn` to automatically close the ISSUE.

- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
GitHub templates

**What is the current behavior?** (You can also link to an open issue here)
No Issue or PR templates are present

**What is the new behavior (if this is a feature change)?**
Issues and PRs will have templates to help standardize submissions

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
